### PR TITLE
fixed roomid to only numerical value

### DIFF
--- a/src/ObjectSettings/ObjectSettings.php
+++ b/src/ObjectSettings/ObjectSettings.php
@@ -162,7 +162,8 @@ class ObjectSettings extends ActiveRecord
 
     public function generareJitsiId(Repository $setting)
     {
-        $uniqid = uniqid('jit', true);
+        //$uniqid = uniqid('jit', true);
+        $uniqid = str_pad(rand(0,'9'.round(microtime(true))),11, "0", STR_PAD_LEFT);
         $this->setJitsiId($uniqid);
         $setting->storeObjectSettings($this);
     }


### PR DESCRIPTION
the rooms could not be initiated properly, because uniqid() produced non alphanumeric values in the roomid which led to an invalid url